### PR TITLE
Feat: Add type alias for public entry point

### DIFF
--- a/gimbap.go
+++ b/gimbap.go
@@ -2,6 +2,34 @@ package gimbap
 
 import (
 	"github.com/jhseong7/gimbap/app"
+	"github.com/jhseong7/gimbap/controller"
+	"github.com/jhseong7/gimbap/engine"
+	"github.com/jhseong7/gimbap/module"
+	"github.com/jhseong7/gimbap/provider"
+)
+
+// type aliases for public apis
+type (
+	// App related
+	AppOption      = app.AppOption
+	GimbapApp      = app.GimbapApp
+	RuntimeOptions = app.RuntimeOptions
+
+	// Module related
+	ModuleOption = module.ModuleOption
+	Module       = module.Module
+
+	// Provider related
+	ProviderDefinition = provider.ProviderDefinition
+
+	// Controller related
+	IController          = controller.IController
+	ControllerDefinition = controller.ControllerDefinition
+	RouteSpec            = controller.RouteSpec
+
+	// Engine related
+	IHttpEngine      = engine.IHttpEngine
+	HttpEngineOption = engine.HttpEngineOption
 )
 
 // Public entry point to create a Gimbap application.


### PR DESCRIPTION
Add type aliases to the public entry point so it is no longer needed to add extra imports to use the core features