### PR TITLE
Refactor: Change HttpEngine to ServerEngine

### DIFF
--- a/dependency/di-manager.go
+++ b/dependency/di-manager.go
@@ -9,6 +9,9 @@ import (
 type (
 	IDependencyManager interface {
 		// ResolveDependencies the dependencies to the target
+		//
+		// The first parameter is the result map which contains the resolved dependencies.
+		// The second parameter is the list of providers to resolve.
 		ResolveDependencies(result map[reflect.Type]reflect.Value, providers []*provider.Provider)
 
 		// Lifecycle methods

--- a/engine/echo-engine.go
+++ b/engine/echo-engine.go
@@ -16,7 +16,7 @@ import (
 
 type (
 	EchoHttpEngine struct {
-		IHttpEngine
+		IServerEngine
 
 		// The underlying http engine
 		engine          *echo.Echo
@@ -99,7 +99,7 @@ func (e *EchoHttpEngine) Run(port int) {
 }
 
 func (e *EchoHttpEngine) Stop() {
-	e.logger.Log("Stopping the http engine")
+	e.logger.Log("Stopping the http engine (Max 5 seconds)")
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 	if err := e.engine.Shutdown(ctx); err != nil {
@@ -138,9 +138,9 @@ func CreateEchoHttpEngine(logger logger.Logger) (e *echo.Echo) {
 }
 
 // Create a new http engine (for now, gin is the only supported engine)
-func NewEchoHttpEngine(options ...HttpEngineOption) *EchoHttpEngine {
+func NewEchoHttpEngine(options ...ServerEngineOption) *EchoHttpEngine {
 	// Get the options
-	var option HttpEngineOption
+	var option ServerEngineOption
 	if len(options) > 0 {
 		option = options[0]
 	}

--- a/engine/fiber-engine.go
+++ b/engine/fiber-engine.go
@@ -14,7 +14,7 @@ import (
 
 type (
 	FiberHttpEngine struct {
-		IHttpEngine
+		IServerEngine
 
 		// The underlying http engine
 		engine          *fiber.App
@@ -23,8 +23,8 @@ type (
 		logger logger.Logger
 	}
 
-	FiberHttpEngineOption struct {
-		HttpEngineOption
+	FiberEngineOption struct {
+		ServerEngineOption
 		FiberConfig fiber.Config
 	}
 
@@ -137,9 +137,9 @@ func CreateFiberHttpEngine(logger logger.Logger, fiberConfig fiber.Config) (e *f
 }
 
 // Create a new http engine (for now, gin is the only supported engine)
-func NewFiberHttpEngine(options ...FiberHttpEngineOption) *FiberHttpEngine {
+func NewFiberHttpEngine(options ...FiberEngineOption) *FiberHttpEngine {
 	// Get the options
-	var option FiberHttpEngineOption
+	var option FiberEngineOption
 	if len(options) > 0 {
 		option = options[0]
 	}

--- a/engine/gin-engine.go
+++ b/engine/gin-engine.go
@@ -16,7 +16,7 @@ import (
 
 type (
 	GinHttpEngine struct {
-		IHttpEngine
+		IServerEngine
 
 		// The underlying http engine
 		engine          *gin.Engine
@@ -106,7 +106,7 @@ func (e *GinHttpEngine) Run(port int) {
 }
 
 func (e *GinHttpEngine) Stop() {
-	e.logger.Log("Stopping the http engine")
+	e.logger.Log("Stopping the http engine (Max 5 seconds)")
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 	if err := e.server.Shutdown(ctx); err != nil {
@@ -131,9 +131,9 @@ func CreateGinHttpEngine(logger logger.Logger) (e *gin.Engine) {
 }
 
 // Create a new http engine (for now, gin is the only supported engine)
-func NewGinHttpEngine(options ...HttpEngineOption) *GinHttpEngine {
+func NewGinHttpEngine(options ...ServerEngineOption) *GinHttpEngine {
 	// Get the options
-	var option HttpEngineOption
+	var option ServerEngineOption
 	if len(options) > 0 {
 		option = options[0]
 	}

--- a/engine/null-engine.go
+++ b/engine/null-engine.go
@@ -7,7 +7,7 @@ import (
 
 type (
 	NullEngine struct {
-		IHttpEngine
+		IServerEngine
 
 		logger logger.Logger
 

--- a/engine/server-engine.go
+++ b/engine/server-engine.go
@@ -15,14 +15,23 @@ import (
 
 type (
 	// The engine must implement this interface to be used in the app.
-	IHttpEngine interface {
+	IServerEngine interface {
+		// Registers a controller to the engine
 		RegisterController(rootPath string, controller controller.IController)
+
+		// Run the server on the specified port
 		Run(port int)
+
+		// Stop the server gracefully
+		// Must implement a timeout if there is a possibility of a hanging.
 		Stop()
+
+		// Add middleware to the engine.
+		// This will be native to the engine's core
 		AddMiddleware(middleware ...interface{})
 	}
 
-	HttpEngineOption struct {
+	ServerEngineOption struct {
 		GlobalApiPrefix string
 	}
 )

--- a/gimbap.go
+++ b/gimbap.go
@@ -32,8 +32,8 @@ type (
 	RouteSpec            = controller.RouteSpec
 
 	// Engine related
-	IHttpEngine      = engine.IHttpEngine
-	HttpEngineOption = engine.HttpEngineOption
+	IServerEngine      = engine.IServerEngine
+	ServerEngineOption = engine.ServerEngineOption
 
 	// Microservice related
 	IMicroService = microservice.IMicroService


### PR DESCRIPTION
Change the name to make the protocols used in the engine more flexible.

If needed, other type of engines can be used instead, such as gRPC, TCP