### PR TITLE
Feat: Add multi return provider to GIMBAP manager

### DIFF
--- a/dependency/gimbap-manager_test.go
+++ b/dependency/gimbap-manager_test.go
@@ -35,8 +35,21 @@ type (
 	// Unresolved dependency tester
 	OrphanA struct{}
 	OprhanB struct{}
+
+	// Multiple dependency return tester
+	MultiA struct{}
+	MultiB struct{}
+	MultiC struct{}
+	MultiD struct{}
+	MultiE struct{}
+	MultiF struct{}
+	MultiG struct{}
+	MultiH struct{}
 )
 
+// A --> B --> C
+// D --> B
+// E --> F --> B
 func NewA() *A                 { return &A{} }
 func NewB(a *A, d *D, f *F) *B { return &B{} }
 func NewC(b *B) *C             { return &C{} }
@@ -44,12 +57,26 @@ func NewD() *D                 { return &D{} }
 func NewE() *E                 { return &E{} }
 func NewF(e *E) *F             { return &F{} }
 
+// Circular dependency tester
+// CirA --> CirB --> CirC --> CirA
 func NewCirA(c *CirC) *CirA { return &CirA{} }
 func NewCirB(a *CirA) *CirB { return &CirB{} }
 func NewCirC(b *CirB) *CirC { return &CirC{} }
 
+// Unresolved dependency tester
+// OrphanA --> OrphanB
+// But will be tested with only OrphanB + A,B,C,D,E,F
 func NewOrphanA() *OrphanA           { return &OrphanA{} }
 func NewOrphanB(a *OrphanA) *OprhanB { return &OprhanB{} }
+
+// Multiple dependency return tester
+// A single instantiator that returns multiple values
+// ABC -> D, D -> EF, E --> G,  F --> H
+func NewMultiABC() (*MultiA, *MultiB, *MultiC)          { return &MultiA{}, &MultiB{}, &MultiC{} }
+func NewMultiD(a *MultiA, b *MultiB, c *MultiC) *MultiD { return &MultiD{} }
+func NewMultiEF(d *MultiD) (*MultiE, *MultiF)           { return &MultiE{}, &MultiF{} }
+func NewMultiG(e *MultiE) *MultiG                       { return &MultiG{} }
+func NewMultiH(f *MultiF) *MultiH                       { return &MultiH{} }
 
 var AProvider = gimbap.DefineProvider(gimbap.ProviderOption{Name: "A", Instantiator: NewA})
 var BProvider = gimbap.DefineProvider(gimbap.ProviderOption{Name: "B", Instantiator: NewB})
@@ -65,15 +92,21 @@ var CirCProvider = gimbap.DefineProvider(gimbap.ProviderOption{Name: "CirC", Ins
 var OrphanAProvider = gimbap.DefineProvider(gimbap.ProviderOption{Name: "OrphanA", Instantiator: NewOrphanA})
 var OrphanBProvider = gimbap.DefineProvider(gimbap.ProviderOption{Name: "OrphanB", Instantiator: NewOrphanB})
 
+var MultiABCProvider = gimbap.DefineProvider(gimbap.ProviderOption{Name: "MultiABC", Instantiator: NewMultiABC})
+var MultiDProvider = gimbap.DefineProvider(gimbap.ProviderOption{Name: "MultiD", Instantiator: NewMultiD})
+var MultiEFProvider = gimbap.DefineProvider(gimbap.ProviderOption{Name: "MultiEF", Instantiator: NewMultiEF})
+var MultiGProvider = gimbap.DefineProvider(gimbap.ProviderOption{Name: "MultiG", Instantiator: NewMultiG})
+var MultiHProvider = gimbap.DefineProvider(gimbap.ProviderOption{Name: "MultiH", Instantiator: NewMultiH})
+
 var _ = Describe("GimbapDependencyManager", func() {
 	gimbapManager := manager.NewGimbapDependencyManager()
 
 	Context("Test resolver", func() {
 		fmt.Println("addProvider")
 
-		instanceMap := make(map[reflect.Type]reflect.Value)
-
 		It("Normal resolving", func() {
+			instanceMap := make(map[reflect.Type]reflect.Value)
+
 			providerList := []*provider.Provider{
 				AProvider,
 				BProvider,
@@ -87,6 +120,8 @@ var _ = Describe("GimbapDependencyManager", func() {
 		})
 
 		It("Circular dependency --> will panic", func() {
+			instanceMap := make(map[reflect.Type]reflect.Value)
+
 			providerList := []*provider.Provider{
 				CirAProvider,
 				CirBProvider,
@@ -99,6 +134,8 @@ var _ = Describe("GimbapDependencyManager", func() {
 		})
 
 		It("Orphan dependency --> will panic", func() {
+			instanceMap := make(map[reflect.Type]reflect.Value)
+
 			providerList := []*provider.Provider{
 				AProvider,
 				BProvider,
@@ -112,6 +149,22 @@ var _ = Describe("GimbapDependencyManager", func() {
 			Expect(func() {
 				gimbapManager.ResolveDependencies(instanceMap, providerList)
 			}).To(Panic())
+		})
+
+		It("Multiple dependency return", func() {
+			instanceMap := make(map[reflect.Type]reflect.Value)
+
+			providerList := []*provider.Provider{
+				MultiABCProvider,
+				MultiDProvider,
+				MultiEFProvider,
+				MultiGProvider,
+				MultiHProvider,
+			}
+
+			gimbapManager.ResolveDependencies(instanceMap, providerList)
+
+			Expect(instanceMap[reflect.TypeOf(&MultiA{})]).ToNot(BeNil())
 		})
 	})
 })

--- a/util/type.go
+++ b/util/type.go
@@ -31,6 +31,31 @@ func DeriveTypeFromInstantiator(instantiator interface{}) (reflect.Type, bool) {
 	return funcType.Out(0), true
 }
 
+// Version of DeriveTypeFromInstantiator that returns multiple return types
+// This returns all the return types of the instantiator function.
+func DeriveTypeListFromInstantiator(instantiator interface{}) ([]reflect.Type, bool) {
+	funcType := reflect.TypeOf(instantiator)
+
+	if funcType.Kind() != reflect.Func {
+		log.Panicf("Instantiator is not a function: %s", funcType.String())
+		return nil, false
+	}
+
+	// Check if the return type exists
+	if funcType.NumOut() == 0 {
+		log.Panicf("Instantiator must have at least one return value: %s", funcType.String())
+		return nil, false
+	}
+
+	// Get the return types
+	returnTypes := make([]reflect.Type, funcType.NumOut())
+	for i := 0; i < funcType.NumOut(); i++ {
+		returnTypes[i] = funcType.Out(i)
+	}
+
+	return returnTypes, true
+}
+
 // Retrive the input types of the instantiator function.
 func DeriveInputTypesFromInstantiator(instantiator interface{}) ([]reflect.Type, bool) {
 	funcType := reflect.TypeOf(instantiator)


### PR DESCRIPTION
Add support for multi return providers to GIMBAP's dependency manager.

```go
func NewMultiABC() (*MultiA, *MultiB, *MultiC)          { return &MultiA{}, &MultiB{}, &MultiC{} }

var MultiABCProvider = gimbap.DefineProvider(gimbap.ProviderOption{Name: "MultiABC", Instantiator: NewMultiABC})
```

## Known bug

There is a bug in the dependency resolver which causes multiple instance creation for multi-return providers
This bug is due to mischecking the visited node checker in the resolver and will be fixed soon