### PR TITLE
Fix: Temporary fix for removing duplicate instance creation

### DIFF
--- a/dependency/gimbap-manager.go
+++ b/dependency/gimbap-manager.go
@@ -80,6 +80,18 @@ func (g *GimbapDependencyManager) createInstancesFromInstantiator(instantiator i
 		return false, fmt.Errorf("failed to derive return types from instantiator")
 	}
 
+	// If the return types are all already created --> skip
+	allInstancesCreated := true
+	for _, returnType := range returnTypes {
+		if _, ok := instanceMap[returnType]; !ok {
+			allInstancesCreated = false
+			break
+		}
+	}
+	if allInstancesCreated {
+		return true, nil
+	}
+
 	// Call the instantiator with the input values
 	returnValues := reflect.ValueOf(instantiator).Call(inputValues)
 


### PR DESCRIPTION
Fixes the call of duplicate instantiator call for multiple return values.

The bug of handling the node multiple times (times the number of return types to be precise) is still present but this fix will solve the issue of multiple calls to the instantiator which can cause issues if the object must be singleton (e.g. DB connection manager)