### PR TITLE
Fix React Server Components security vulnerability

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -10,7 +10,7 @@
   "dependencies": {
     "@vercel/analytics": "^1.4.1",
     "@vercel/speed-insights": "^1.1.0",
-    "next": "^14",
+    "next": "14.2.26",
     "nextra": "^3",
     "nextra-theme-docs": "^3",
     "react": "^18.2.0",


### PR DESCRIPTION
Pin Next.js to explicit version 14.2.26 to prevent accidental upgrades to potentially vulnerable versions. Per the React team's security advisory, stable Next.js 14.x releases are not affected by CVE-2025-55182, but pinning ensures no future surprises.

The vulnerability affects react-server-dom-* packages in React 19.x and Next.js 15.x/16.x. This project uses React 18.x with stable Next.js 14.x and has no react-server-dom packages installed.